### PR TITLE
Fix false positive for drift detection

### DIFF
--- a/PagerDuty-EscalationPolicies-EscalationPolicy/docs/service.md
+++ b/PagerDuty-EscalationPolicies-EscalationPolicy/docs/service.md
@@ -9,9 +9,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 {
     "<a href="#type" title="Type">Type</a>" : <i>String</i>,
-    "<a href="#id" title="Id">Id</a>" : <i>String</i>,
-    "<a href="#summary" title="Summary">Summary</a>" : <i>String</i>,
-    "<a href="#htmlurl" title="HtmlUrl">HtmlUrl</a>" : <i>String</i>
+    "<a href="#id" title="Id">Id</a>" : <i>String</i>
 }
 </pre>
 
@@ -20,8 +18,6 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 <a href="#type" title="Type">Type</a>: <i>String</i>
 <a href="#id" title="Id">Id</a>: <i>String</i>
-<a href="#summary" title="Summary">Summary</a>: <i>String</i>
-<a href="#htmlurl" title="HtmlUrl">HtmlUrl</a>: <i>String</i>
 </pre>
 
 ## Properties
@@ -41,26 +37,6 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 #### Id
 
 _Required_: Yes
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### Summary
-
-A short-form, server-generated string that provides succinct, important information about an object suitable for primary labeling of an entity in a client. In many cases, this will be identical to name, though it is not intended to be an identifier.
-
-_Required_: No
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### HtmlUrl
-
-A URL at which the entity is uniquely displayed in the Web app.
-
-_Required_: No
 
 _Type_: String
 

--- a/PagerDuty-EscalationPolicies-EscalationPolicy/docs/target.md
+++ b/PagerDuty-EscalationPolicies-EscalationPolicy/docs/target.md
@@ -9,9 +9,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 {
     "<a href="#type" title="Type">Type</a>" : <i>String</i>,
-    "<a href="#id" title="Id">Id</a>" : <i>String</i>,
-    "<a href="#summary" title="Summary">Summary</a>" : <i>String</i>,
-    "<a href="#htmlurl" title="HtmlUrl">HtmlUrl</a>" : <i>String</i>
+    "<a href="#id" title="Id">Id</a>" : <i>String</i>
 }
 </pre>
 
@@ -20,8 +18,6 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 <a href="#type" title="Type">Type</a>: <i>String</i>
 <a href="#id" title="Id">Id</a>: <i>String</i>
-<a href="#summary" title="Summary">Summary</a>: <i>String</i>
-<a href="#htmlurl" title="HtmlUrl">HtmlUrl</a>: <i>String</i>
 </pre>
 
 ## Properties
@@ -41,26 +37,6 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 #### Id
 
 _Required_: Yes
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### Summary
-
-A short-form, server-generated string that provides succinct, important information about an object suitable for primary labeling of an entity in a client. In many cases, this will be identical to name, though it is not intended to be an identifier.
-
-_Required_: No
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### HtmlUrl
-
-A URL at which the entity is uniquely displayed in the Web app.
-
-_Required_: No
 
 _Type_: String
 

--- a/PagerDuty-EscalationPolicies-EscalationPolicy/docs/team.md
+++ b/PagerDuty-EscalationPolicies-EscalationPolicy/docs/team.md
@@ -9,9 +9,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 {
     "<a href="#type" title="Type">Type</a>" : <i>String</i>,
-    "<a href="#id" title="Id">Id</a>" : <i>String</i>,
-    "<a href="#summary" title="Summary">Summary</a>" : <i>String</i>,
-    "<a href="#htmlurl" title="HtmlUrl">HtmlUrl</a>" : <i>String</i>
+    "<a href="#id" title="Id">Id</a>" : <i>String</i>
 }
 </pre>
 
@@ -20,8 +18,6 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 <a href="#type" title="Type">Type</a>: <i>String</i>
 <a href="#id" title="Id">Id</a>: <i>String</i>
-<a href="#summary" title="Summary">Summary</a>: <i>String</i>
-<a href="#htmlurl" title="HtmlUrl">HtmlUrl</a>: <i>String</i>
 </pre>
 
 ## Properties
@@ -41,26 +37,6 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 #### Id
 
 _Required_: Yes
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### Summary
-
-A short-form, server-generated string that provides succinct, important information about an object suitable for primary labeling of an entity in a client. In many cases, this will be identical to name, though it is not intended to be an identifier.
-
-_Required_: No
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### HtmlUrl
-
-A URL at which the entity is uniquely displayed in the Web app.
-
-_Required_: No
 
 _Type_: String
 

--- a/PagerDuty-EscalationPolicies-EscalationPolicy/pagerduty-escalationpolicies-escalationpolicy.json
+++ b/PagerDuty-EscalationPolicies-EscalationPolicy/pagerduty-escalationpolicies-escalationpolicy.json
@@ -8,8 +8,7 @@
       "properties": {
         "Token": {
           "description": "Personal Access Token",
-          "type": "string",
-          "pattern": "^\\S{20}$"
+          "type": "string"
         }
       },
       "required": [
@@ -59,12 +58,6 @@
         },
         "Id": {
           "$ref": "#/definitions/Id"
-        },
-        "Summary": {
-          "$ref": "#/definitions/Summary"
-        },
-        "HtmlUrl": {
-          "$ref": "#/definitions/HtmlUrl"
         }
       },
       "required": [
@@ -85,12 +78,6 @@
         },
         "Id": {
           "$ref": "#/definitions/Id"
-        },
-        "Summary": {
-          "$ref": "#/definitions/Summary"
-        },
-        "HtmlUrl": {
-          "$ref": "#/definitions/HtmlUrl"
         }
       },
       "required": [
@@ -111,12 +98,6 @@
         },
         "Id": {
           "$ref": "#/definitions/Id"
-        },
-        "Summary": {
-          "$ref": "#/definitions/Summary"
-        },
-        "HtmlUrl": {
-          "$ref": "#/definitions/HtmlUrl"
         }
       },
       "required": [

--- a/PagerDuty-EscalationPolicies-EscalationPolicy/src/handlers.ts
+++ b/PagerDuty-EscalationPolicies-EscalationPolicy/src/handlers.ts
@@ -73,9 +73,6 @@ class Resource extends AbstractPagerDutyResource<ResourceModel, EscalationPolicy
             return model;
         }
 
-        delete from.escalation_rules;
-        delete from.teams;
-
         return new ResourceModel({
             ...model,
             ...Transformer.for(from)

--- a/PagerDuty-EscalationPolicies-EscalationPolicy/src/models.ts
+++ b/PagerDuty-EscalationPolicies-EscalationPolicy/src/models.ts
@@ -162,24 +162,6 @@ export class Target extends BaseModel {
         }
     )
     id?: Optional<string>;
-    @Expose({ name: 'Summary' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'summary', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    summary?: Optional<string>;
-    @Expose({ name: 'HtmlUrl' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'htmlUrl', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    htmlUrl?: Optional<string>;
 
 }
 
@@ -205,24 +187,6 @@ export class Team extends BaseModel {
         }
     )
     id?: Optional<string>;
-    @Expose({ name: 'Summary' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'summary', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    summary?: Optional<string>;
-    @Expose({ name: 'HtmlUrl' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'htmlUrl', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    htmlUrl?: Optional<string>;
 
 }
 
@@ -248,24 +212,6 @@ export class Service extends BaseModel {
         }
     )
     id?: Optional<string>;
-    @Expose({ name: 'Summary' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'summary', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    summary?: Optional<string>;
-    @Expose({ name: 'HtmlUrl' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'htmlUrl', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    htmlUrl?: Optional<string>;
 
 }
 

--- a/PagerDuty-ResponsePlays-ResponsePlay/docs/responder.md
+++ b/PagerDuty-ResponsePlays-ResponsePlay/docs/responder.md
@@ -9,9 +9,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 {
     "<a href="#type" title="Type">Type</a>" : <i>String</i>,
-    "<a href="#id" title="Id">Id</a>" : <i>String</i>,
-    "<a href="#summary" title="Summary">Summary</a>" : <i>String</i>,
-    "<a href="#htmlurl" title="HtmlUrl">HtmlUrl</a>" : <i>String</i>
+    "<a href="#id" title="Id">Id</a>" : <i>String</i>
 }
 </pre>
 
@@ -20,8 +18,6 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 <a href="#type" title="Type">Type</a>: <i>String</i>
 <a href="#id" title="Id">Id</a>: <i>String</i>
-<a href="#summary" title="Summary">Summary</a>: <i>String</i>
-<a href="#htmlurl" title="HtmlUrl">HtmlUrl</a>: <i>String</i>
 </pre>
 
 ## Properties
@@ -41,26 +37,6 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 #### Id
 
 _Required_: Yes
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### Summary
-
-A short-form, server-generated string that provides succinct, important information about an object suitable for primary labeling of an entity in a client. In many cases, this will be identical to name, though it is not intended to be an identifier.
-
-_Required_: No
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### HtmlUrl
-
-A URL at which the entity is uniquely displayed in the Web app.
-
-_Required_: No
 
 _Type_: String
 

--- a/PagerDuty-ResponsePlays-ResponsePlay/docs/subscriber.md
+++ b/PagerDuty-ResponsePlays-ResponsePlay/docs/subscriber.md
@@ -9,9 +9,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 {
     "<a href="#type" title="Type">Type</a>" : <i>String</i>,
-    "<a href="#id" title="Id">Id</a>" : <i>String</i>,
-    "<a href="#summary" title="Summary">Summary</a>" : <i>String</i>,
-    "<a href="#htmlurl" title="HtmlUrl">HtmlUrl</a>" : <i>String</i>
+    "<a href="#id" title="Id">Id</a>" : <i>String</i>
 }
 </pre>
 
@@ -20,8 +18,6 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 <a href="#type" title="Type">Type</a>: <i>String</i>
 <a href="#id" title="Id">Id</a>: <i>String</i>
-<a href="#summary" title="Summary">Summary</a>: <i>String</i>
-<a href="#htmlurl" title="HtmlUrl">HtmlUrl</a>: <i>String</i>
 </pre>
 
 ## Properties
@@ -41,26 +37,6 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 #### Id
 
 _Required_: Yes
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### Summary
-
-A short-form, server-generated string that provides succinct, important information about an object suitable for primary labeling of an entity in a client. In many cases, this will be identical to name, though it is not intended to be an identifier.
-
-_Required_: No
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### HtmlUrl
-
-A URL at which the entity is uniquely displayed in the Web app.
-
-_Required_: No
 
 _Type_: String
 

--- a/PagerDuty-ResponsePlays-ResponsePlay/docs/team.md
+++ b/PagerDuty-ResponsePlays-ResponsePlay/docs/team.md
@@ -9,9 +9,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 {
     "<a href="#type" title="Type">Type</a>" : <i>String</i>,
-    "<a href="#id" title="Id">Id</a>" : <i>String</i>,
-    "<a href="#summary" title="Summary">Summary</a>" : <i>String</i>,
-    "<a href="#htmlurl" title="HtmlUrl">HtmlUrl</a>" : <i>String</i>
+    "<a href="#id" title="Id">Id</a>" : <i>String</i>
 }
 </pre>
 
@@ -20,8 +18,6 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 <a href="#type" title="Type">Type</a>: <i>String</i>
 <a href="#id" title="Id">Id</a>: <i>String</i>
-<a href="#summary" title="Summary">Summary</a>: <i>String</i>
-<a href="#htmlurl" title="HtmlUrl">HtmlUrl</a>: <i>String</i>
 </pre>
 
 ## Properties
@@ -41,26 +37,6 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 #### Id
 
 _Required_: Yes
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### Summary
-
-A short-form, server-generated string that provides succinct, important information about an object suitable for primary labeling of an entity in a client. In many cases, this will be identical to name, though it is not intended to be an identifier.
-
-_Required_: No
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### HtmlUrl
-
-A URL at which the entity is uniquely displayed in the Web app.
-
-_Required_: No
 
 _Type_: String
 

--- a/PagerDuty-ResponsePlays-ResponsePlay/pagerduty-responseplays-responseplay.json
+++ b/PagerDuty-ResponsePlays-ResponsePlay/pagerduty-responseplays-responseplay.json
@@ -8,8 +8,7 @@
       "properties": {
         "Token": {
           "description": "Personal Access Token",
-          "type": "string",
-          "pattern": "^\\S{20}$"
+          "type": "string"
         }
       },
       "required": [
@@ -40,12 +39,6 @@
         },
         "Id": {
           "$ref": "#/definitions/Id"
-        },
-        "Summary": {
-          "$ref": "#/definitions/Summary"
-        },
-        "HtmlUrl": {
-          "$ref": "#/definitions/HtmlUrl"
         }
       },
       "required": [
@@ -67,12 +60,6 @@
         },
         "Id": {
           "$ref": "#/definitions/Id"
-        },
-        "Summary": {
-          "$ref": "#/definitions/Summary"
-        },
-        "HtmlUrl": {
-          "$ref": "#/definitions/HtmlUrl"
         }
       },
       "required": [
@@ -94,12 +81,6 @@
         },
         "Id": {
           "$ref": "#/definitions/Id"
-        },
-        "Summary": {
-          "$ref": "#/definitions/Summary"
-        },
-        "HtmlUrl": {
-          "$ref": "#/definitions/HtmlUrl"
         }
       },
       "required": [

--- a/PagerDuty-ResponsePlays-ResponsePlay/src/handlers.ts
+++ b/PagerDuty-ResponsePlays-ResponsePlay/src/handlers.ts
@@ -99,27 +99,6 @@ class Resource extends AbstractPagerDutyResource<ResourceModel, ResponsePlayPayl
             return model;
         }
 
-        if (from.description === null) {
-            delete from.description;
-        }
-        if (from.subscribers_message === null) {
-            delete from.subscribers_message;
-        }
-        if (from.responders_message === null) {
-            delete from.responders_message;
-        }
-        if (from.conference_number === null) {
-            delete from.conference_number;
-        }
-        if (from.conference_url === null) {
-            delete from.conference_url;
-        }
-        if (from.conference_type === null) {
-            delete from.conference_type;
-        }
-        delete from.subscribers;
-        delete from.responders;
-
         return new ResourceModel({
             ...model,
             ...Transformer.for(from)

--- a/PagerDuty-ResponsePlays-ResponsePlay/src/models.ts
+++ b/PagerDuty-ResponsePlays-ResponsePlay/src/models.ts
@@ -185,24 +185,6 @@ export class Team extends BaseModel {
         }
     )
     id?: Optional<string>;
-    @Expose({ name: 'Summary' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'summary', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    summary?: Optional<string>;
-    @Expose({ name: 'HtmlUrl' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'htmlUrl', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    htmlUrl?: Optional<string>;
 
 }
 
@@ -228,24 +210,6 @@ export class Subscriber extends BaseModel {
         }
     )
     id?: Optional<string>;
-    @Expose({ name: 'Summary' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'summary', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    summary?: Optional<string>;
-    @Expose({ name: 'HtmlUrl' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'htmlUrl', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    htmlUrl?: Optional<string>;
 
 }
 
@@ -271,24 +235,6 @@ export class Responder extends BaseModel {
         }
     )
     id?: Optional<string>;
-    @Expose({ name: 'Summary' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'summary', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    summary?: Optional<string>;
-    @Expose({ name: 'HtmlUrl' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'htmlUrl', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    htmlUrl?: Optional<string>;
 
 }
 
@@ -315,32 +261,6 @@ export class PagerDutyAccess extends BaseModel {
         }
     )
     token?: Optional<string>;
-
-}
-
-export class TypeConfigurationModel extends BaseModel {
-    ['constructor']: typeof TypeConfigurationModel;
-
-
-    @Expose({ name: 'PagerDutyAccess' })
-    @Type(() => PagerDutyAccess)
-    pagerDutyAccess?: Optional<PagerDutyAccess>;
-
-}
-
-export class PagerDutyAccess extends BaseModel {
-    ['constructor']: typeof PagerDutyAccess;
-
-
-    @Expose({ name: 'AccessToken' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'accessToken', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    accessToken?: Optional<string>;
 
 }
 

--- a/PagerDuty-Schedules-Schedule/docs/escalationpolicy.md
+++ b/PagerDuty-Schedules-Schedule/docs/escalationpolicy.md
@@ -9,9 +9,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 {
     "<a href="#type" title="Type">Type</a>" : <i>String</i>,
-    "<a href="#id" title="Id">Id</a>" : <i>String</i>,
-    "<a href="#summary" title="Summary">Summary</a>" : <i>String</i>,
-    "<a href="#htmlurl" title="HtmlUrl">HtmlUrl</a>" : <i>String</i>
+    "<a href="#id" title="Id">Id</a>" : <i>String</i>
 }
 </pre>
 
@@ -20,8 +18,6 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 <a href="#type" title="Type">Type</a>: <i>String</i>
 <a href="#id" title="Id">Id</a>: <i>String</i>
-<a href="#summary" title="Summary">Summary</a>: <i>String</i>
-<a href="#htmlurl" title="HtmlUrl">HtmlUrl</a>: <i>String</i>
 </pre>
 
 ## Properties
@@ -45,26 +41,6 @@ _Required_: Yes
 _Type_: String
 
 _Minimum_: <code>1</code>
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### Summary
-
-A short-form, server-generated string that provides succinct, important information about an object suitable for primary labeling of an entity in a client. In many cases, this will be identical to name, though it is not intended to be an identifier.
-
-_Required_: No
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### HtmlUrl
-
-A URL at which the entity is uniquely displayed in the Web app.
-
-_Required_: No
-
-_Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/PagerDuty-Schedules-Schedule/docs/restriction.md
+++ b/PagerDuty-Schedules-Schedule/docs/restriction.md
@@ -56,6 +56,8 @@ _Required_: Yes
 
 _Type_: String
 
+_Pattern_: <code>([0-1][0-9]|2[0-3])(:[0-5][0-9]){2}</code>
+
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### StartDayOfWeek

--- a/PagerDuty-Schedules-Schedule/docs/team.md
+++ b/PagerDuty-Schedules-Schedule/docs/team.md
@@ -9,9 +9,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 {
     "<a href="#type" title="Type">Type</a>" : <i>String</i>,
-    "<a href="#id" title="Id">Id</a>" : <i>String</i>,
-    "<a href="#summary" title="Summary">Summary</a>" : <i>String</i>,
-    "<a href="#htmlurl" title="HtmlUrl">HtmlUrl</a>" : <i>String</i>
+    "<a href="#id" title="Id">Id</a>" : <i>String</i>
 }
 </pre>
 
@@ -20,8 +18,6 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 <a href="#type" title="Type">Type</a>: <i>String</i>
 <a href="#id" title="Id">Id</a>: <i>String</i>
-<a href="#summary" title="Summary">Summary</a>: <i>String</i>
-<a href="#htmlurl" title="HtmlUrl">HtmlUrl</a>: <i>String</i>
 </pre>
 
 ## Properties
@@ -45,26 +41,6 @@ _Required_: Yes
 _Type_: String
 
 _Minimum_: <code>1</code>
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### Summary
-
-A short-form, server-generated string that provides succinct, important information about an object suitable for primary labeling of an entity in a client. In many cases, this will be identical to name, though it is not intended to be an identifier.
-
-_Required_: No
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### HtmlUrl
-
-A URL at which the entity is uniquely displayed in the Web app.
-
-_Required_: No
-
-_Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/PagerDuty-Schedules-Schedule/docs/user.md
+++ b/PagerDuty-Schedules-Schedule/docs/user.md
@@ -9,9 +9,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 {
     "<a href="#type" title="Type">Type</a>" : <i>String</i>,
-    "<a href="#id" title="Id">Id</a>" : <i>String</i>,
-    "<a href="#summary" title="Summary">Summary</a>" : <i>String</i>,
-    "<a href="#htmlurl" title="HtmlUrl">HtmlUrl</a>" : <i>String</i>
+    "<a href="#id" title="Id">Id</a>" : <i>String</i>
 }
 </pre>
 
@@ -20,8 +18,6 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 <a href="#type" title="Type">Type</a>: <i>String</i>
 <a href="#id" title="Id">Id</a>: <i>String</i>
-<a href="#summary" title="Summary">Summary</a>: <i>String</i>
-<a href="#htmlurl" title="HtmlUrl">HtmlUrl</a>: <i>String</i>
 </pre>
 
 ## Properties
@@ -45,26 +41,6 @@ _Required_: Yes
 _Type_: String
 
 _Minimum_: <code>1</code>
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### Summary
-
-A short-form, server-generated string that provides succinct, important information about an object suitable for primary labeling of an entity in a client. In many cases, this will be identical to name, though it is not intended to be an identifier.
-
-_Required_: No
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### HtmlUrl
-
-A URL at which the entity is uniquely displayed in the Web app.
-
-_Required_: No
-
-_Type_: String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/PagerDuty-Schedules-Schedule/pagerduty-schedules-schedule.json
+++ b/PagerDuty-Schedules-Schedule/pagerduty-schedules-schedule.json
@@ -8,8 +8,7 @@
       "properties": {
         "Token": {
           "description": "Personal Access Token",
-          "type": "string",
-          "pattern": "^\\w{20}$"
+          "type": "string"
         }
       },
       "required": [
@@ -103,7 +102,7 @@
         "StartTimeOfDay": {
           "description": "The start time in HH:mm:ss format.",
           "type": "string",
-          "format": "time"
+          "pattern": "([0-1][0-9]|2[0-3])(:[0-5][0-9]){2}"
         },
         "StartDayOfWeek": {
           "description": "Only required for use with a weekly_restriction restriction type. The first day of the weekly rotation schedule as ISO 8601 day (1 is Monday, etc.)",
@@ -183,13 +182,6 @@
         },
         "Id": {
           "$ref": "#/definitions/Id"
-        },
-        "Summary": {
-          "description": "A short-form, server-generated string that provides succinct, important information about an object suitable for primary labeling of an entity in a client. In many cases, this will be identical to name, though it is not intended to be an identifier.",
-          "type": "string"
-        },
-        "HtmlUrl": {
-          "$ref": "#/definitions/HtmlUrl"
         }
       },
       "required": [
@@ -222,13 +214,6 @@
         },
         "Id": {
           "$ref": "#/definitions/Id"
-        },
-        "Summary": {
-          "description": "A short-form, server-generated string that provides succinct, important information about an object suitable for primary labeling of an entity in a client. In many cases, this will be identical to name, though it is not intended to be an identifier.",
-          "type": "string"
-        },
-        "HtmlUrl": {
-          "$ref": "#/definitions/HtmlUrl"
         }
       },
       "required": [
@@ -249,13 +234,6 @@
         },
         "Id": {
           "$ref": "#/definitions/Id"
-        },
-        "Summary": {
-          "description": "A short-form, server-generated string that provides succinct, important information about an object suitable for primary labeling of an entity in a client. In many cases, this will be identical to name, though it is not intended to be an identifier.",
-          "type": "string"
-        },
-        "HtmlUrl": {
-          "$ref": "#/definitions/HtmlUrl"
         }
       },
       "required": [

--- a/PagerDuty-Schedules-Schedule/src/handlers.ts
+++ b/PagerDuty-Schedules-Schedule/src/handlers.ts
@@ -74,14 +74,6 @@ class Resource extends AbstractPagerDutyResource<ResourceModel, SchedulePayload,
             return model
         }
 
-        delete from.schedule_layers;
-        if (from.final_schedule === null || !model.finalSchedule) {
-            delete from.final_schedule;
-        }
-        if (from.overrides_subschedule === null || !model.overridesSubschedule) {
-            delete from.overrides_subschedule;
-        }
-
         return new ResourceModel({
             ...model,
             ...Transformer.for(from)

--- a/PagerDuty-Schedules-Schedule/src/models.ts
+++ b/PagerDuty-Schedules-Schedule/src/models.ts
@@ -211,24 +211,6 @@ export class User extends BaseModel {
         }
     )
     id?: Optional<string>;
-    @Expose({ name: 'Summary' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'summary', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    summary?: Optional<string>;
-    @Expose({ name: 'HtmlUrl' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'htmlUrl', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    htmlUrl?: Optional<string>;
 
 }
 
@@ -353,24 +335,6 @@ export class EscalationPolicy extends BaseModel {
         }
     )
     id?: Optional<string>;
-    @Expose({ name: 'Summary' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'summary', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    summary?: Optional<string>;
-    @Expose({ name: 'HtmlUrl' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'htmlUrl', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    htmlUrl?: Optional<string>;
 
 }
 
@@ -396,24 +360,6 @@ export class Team extends BaseModel {
         }
     )
     id?: Optional<string>;
-    @Expose({ name: 'Summary' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'summary', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    summary?: Optional<string>;
-    @Expose({ name: 'HtmlUrl' })
-    @Transform(
-        (value: any, obj: any) =>
-            transformValue(String, 'htmlUrl', value, obj, []),
-        {
-            toClassOnly: true,
-        }
-    )
-    htmlUrl?: Optional<string>;
 
 }
 

--- a/PagerDuty-Teams-Membership/pagerduty-teams-membership.json
+++ b/PagerDuty-Teams-Membership/pagerduty-teams-membership.json
@@ -8,8 +8,7 @@
       "properties": {
         "Token": {
           "description": "Personal Access Token",
-          "type": "string",
-          "pattern": "^\\S{20}$"
+          "type": "string"
         }
       },
       "required": [

--- a/PagerDuty-Teams-Team/pagerduty-teams-team.json
+++ b/PagerDuty-Teams-Team/pagerduty-teams-team.json
@@ -8,8 +8,7 @@
       "properties": {
         "Token": {
           "description": "Personal Access Token",
-          "type": "string",
-          "pattern": "^\\S{20}$"
+          "type": "string"
         }
       },
       "required": [

--- a/PagerDuty-Users-User/overrides.json
+++ b/PagerDuty-Users-User/overrides.json
@@ -2,7 +2,7 @@
   "CREATE": {
     "/Email": "info@acme.com",
     "/Color": "green",
-    "/TimeZone": null,
+    "/TimeZone": "Europe/London",
     "/Role": "user"
   }
 }

--- a/PagerDuty-Users-User/pagerduty-users-user.json
+++ b/PagerDuty-Users-User/pagerduty-users-user.json
@@ -8,8 +8,7 @@
       "properties": {
         "Token": {
           "description": "Personal Access Token",
-          "type": "string",
-          "pattern": "^\\S{20}$"
+          "type": "string"
         }
       },
       "required": [

--- a/PagerDuty-Users-User/src/handlers.ts
+++ b/PagerDuty-Users-User/src/handlers.ts
@@ -65,8 +65,6 @@ class Resource extends AbstractPagerDutyResource<ResourceModel, UserPayload, Use
             return model;
         }
 
-        delete from.time_zone;
-
         return new ResourceModel({
             ...model,
             ...Transformer.for(from)


### PR DESCRIPTION
The rule of thumb is to:
- model only the properties that a user can set/use
- return the object from the read handler after the create handler stabilization (to avoid drift for non-set properties in the template, but assigned default by PagerDuty)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.