### PR TITLE
fix version of typescript lib to match the upgrade in pr 43

### DIFF
--- a/PagerDuty-Services-Integration/package-lock.json
+++ b/PagerDuty-Services-Integration/package-lock.json
@@ -8,7 +8,7 @@
             "name": "pagerduty-services-integration",
             "version": "0.1.0",
             "dependencies": {
-                "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "1.0.3",
+                "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "1.0.5",
                 "axios": "^0.27.2",
                 "class-transformer": "0.3.1"
             },
@@ -21,9 +21,9 @@
             }
         },
         "node_modules/@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib/-/cloudformation-cli-typescript-lib-1.0.3.tgz",
-            "integrity": "sha512-t7wSGlcz+Mcf6d2D0cHfum+C9aXEJCvuQQ0oClGa04HrSAoXNxilS4GIt3AlX90YcsFPeN/L7tMzqo4yrVjJFQ==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib/-/cloudformation-cli-typescript-lib-1.0.5.tgz",
+            "integrity": "sha512-O4VM2E9R4qTqMXW1BWsVWq+uQkm8x7xX9XhFUK/UBzj9ILd11y9afdrYKiubcYJAE7wNG7tGfyOf4vic2+BM8w==",
             "dependencies": {
                 "@org-formation/tombok": "^0.0.1",
                 "autobind-decorator": "^2.4.0",
@@ -118,9 +118,9 @@
             }
         },
         "node_modules/aws-sdk": {
-            "version": "2.1474.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1474.0.tgz",
-            "integrity": "sha512-yhIJuBMnLkf+zVj7FI6eYfTwe4ulSo9in3X7Owgc4Bc4Pd0SB8FV5l+zHYGq3G2uZKbzdBkDVohUgBpHfHTocw==",
+            "version": "2.1512.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1512.0.tgz",
+            "integrity": "sha512-+YYS18VsMUdUaZdsVsE+heJmrAwbxcbyw/9B6Ck90ehlRjjU2SELKH7zhpxbgRH00z8Z4ltaLwRhsp69kLHflQ==",
             "optional": true,
             "dependencies": {
                 "buffer": "4.9.2",
@@ -188,12 +188,13 @@
             }
         },
         "node_modules/call-bind": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+            "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.1",
+                "set-function-length": "^1.1.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -253,25 +254,25 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.2.tgz",
-            "integrity": "sha512-YoxfFcDmhjOgWPWsV13+2RNjq1F6UQnfs+8TftwNqtzlmFzEXvlUwdrNrYeaizfjQzRMxkZ6ElWMOJIFKdVqwA==",
+            "version": "1.22.3",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.3.tgz",
+            "integrity": "sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==",
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.0",
                 "arraybuffer.prototype.slice": "^1.0.2",
                 "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
+                "call-bind": "^1.0.5",
                 "es-set-tostringtag": "^2.0.1",
                 "es-to-primitive": "^1.2.1",
                 "function.prototype.name": "^1.1.6",
-                "get-intrinsic": "^1.2.1",
+                "get-intrinsic": "^1.2.2",
                 "get-symbol-description": "^1.0.0",
                 "globalthis": "^1.0.3",
                 "gopd": "^1.0.1",
-                "has": "^1.0.3",
                 "has-property-descriptors": "^1.0.0",
                 "has-proto": "^1.0.1",
                 "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0",
                 "internal-slot": "^1.0.5",
                 "is-array-buffer": "^3.0.2",
                 "is-callable": "^1.2.7",
@@ -281,7 +282,7 @@
                 "is-string": "^1.0.7",
                 "is-typed-array": "^1.1.12",
                 "is-weakref": "^1.0.2",
-                "object-inspect": "^1.12.3",
+                "object-inspect": "^1.13.1",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.4",
                 "regexp.prototype.flags": "^1.5.1",
@@ -295,7 +296,7 @@
                 "typed-array-byte-offset": "^1.0.0",
                 "typed-array-length": "^1.0.4",
                 "unbox-primitive": "^1.0.2",
-                "which-typed-array": "^1.1.11"
+                "which-typed-array": "^1.1.13"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -305,13 +306,13 @@
             }
         },
         "node_modules/es-set-tostringtag": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
-            "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
+            "integrity": "sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==",
             "dependencies": {
-                "get-intrinsic": "^1.1.3",
-                "has": "^1.0.3",
-                "has-tostringtag": "^1.0.0"
+                "get-intrinsic": "^1.2.2",
+                "has-tostringtag": "^1.0.0",
+                "hasown": "^2.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -416,14 +417,14 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-            "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+            "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
+                "function-bind": "^1.1.2",
                 "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3"
+                "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -469,14 +470,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/has": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
-            "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/has-bigints": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -486,11 +479,11 @@
             }
         },
         "node_modules/has-property-descriptors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-            "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+            "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
             "dependencies": {
-                "get-intrinsic": "^1.1.1"
+                "get-intrinsic": "^1.2.2"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -532,6 +525,17 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/hasown": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+            "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/ieee754": {
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -545,12 +549,12 @@
             "optional": true
         },
         "node_modules/internal-slot": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
-            "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
+            "integrity": "sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==",
             "dependencies": {
-                "get-intrinsic": "^1.2.0",
-                "has": "^1.0.3",
+                "get-intrinsic": "^1.2.2",
+                "hasown": "^2.0.0",
                 "side-channel": "^1.0.4"
             },
             "engines": {
@@ -791,9 +795,9 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.0.tgz",
-            "integrity": "sha512-HQ4J+ic8hKrgIt3mqk6cVOVrW2ozL4KdvHlqpBv9vDYWx9ysAgENAdvy4FoGF+KFdhR7nQTNm5J0ctAeOwn+3g==",
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+            "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -807,12 +811,12 @@
             }
         },
         "node_modules/object.assign": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-            "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+            "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.4",
+                "call-bind": "^1.0.5",
+                "define-properties": "^1.2.1",
                 "has-symbols": "^1.0.3",
                 "object-keys": "^1.1.1"
             },
@@ -900,6 +904,20 @@
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
             "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
             "optional": true
+        },
+        "node_modules/set-function-length": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
+            "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+            "dependencies": {
+                "define-data-property": "^1.1.1",
+                "get-intrinsic": "^1.2.1",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/set-function-name": {
             "version": "2.0.1",
@@ -1120,12 +1138,12 @@
             }
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
-            "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
+            "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
             "dependencies": {
                 "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
+                "call-bind": "^1.0.4",
                 "for-each": "^0.3.3",
                 "gopd": "^1.0.1",
                 "has-tostringtag": "^1.0.0"

--- a/PagerDuty-Services-Integration/package.json
+++ b/PagerDuty-Services-Integration/package.json
@@ -13,7 +13,7 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "1.0.3",
+        "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "1.0.5",
         "axios": "^0.27.2",
         "class-transformer": "0.3.1"
     },


### PR DESCRIPTION
In PR 43, the version of: `@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib` has been bumped for all resources. Since the Integration resource has been implemented in parallel, the version of the lib was not updated for it and after merging PR 43 will be out of sync with other resources.

This PR updates version of lib for Integration resource `1.0.3`-> `1.0.5`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.