### PR TITLE
update version of typescript lib to 1.0.5

### DIFF
--- a/PagerDuty-Services-Service/package-lock.json
+++ b/PagerDuty-Services-Service/package-lock.json
@@ -8,7 +8,7 @@
             "name": "pagerduty-services-service",
             "version": "0.1.0",
             "dependencies": {
-                "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "1.0.3",
+                "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.5",
                 "axios": "^0.27.2",
                 "class-transformer": "0.3.1"
             },
@@ -21,9 +21,9 @@
             }
         },
         "node_modules/@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib/-/cloudformation-cli-typescript-lib-1.0.3.tgz",
-            "integrity": "sha512-t7wSGlcz+Mcf6d2D0cHfum+C9aXEJCvuQQ0oClGa04HrSAoXNxilS4GIt3AlX90YcsFPeN/L7tMzqo4yrVjJFQ==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib/-/cloudformation-cli-typescript-lib-1.0.5.tgz",
+            "integrity": "sha512-O4VM2E9R4qTqMXW1BWsVWq+uQkm8x7xX9XhFUK/UBzj9ILd11y9afdrYKiubcYJAE7wNG7tGfyOf4vic2+BM8w==",
             "dependencies": {
                 "@org-formation/tombok": "^0.0.1",
                 "autobind-decorator": "^2.4.0",
@@ -118,9 +118,9 @@
             }
         },
         "node_modules/aws-sdk": {
-            "version": "2.1472.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1472.0.tgz",
-            "integrity": "sha512-U7kAHRbvTy753IXKV8Oom/AqlqnsbXG+Kw5gRbKi6VcsZ3hR/EpNMzdRXTWO5U415bnLWGo8WAqIz67PIaaKsw==",
+            "version": "2.1514.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1514.0.tgz",
+            "integrity": "sha512-ZQE5kHhJozwBB+Zaa21Gglm2pSQVU+8fFZNOn4pr+Kc1scYPlmVBPR3a0w19Vc4HNXPzjApAk2G4xMvzZDktAw==",
             "optional": true,
             "dependencies": {
                 "buffer": "4.9.2",
@@ -136,16 +136,6 @@
             },
             "engines": {
                 "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/aws-sdk/node_modules/querystring": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-            "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-            "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-            "optional": true,
-            "engines": {
-                "node": ">=0.4.x"
             }
         },
         "node_modules/aws-sdk/node_modules/uuid": {
@@ -198,12 +188,13 @@
             }
         },
         "node_modules/call-bind": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+            "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.1",
+                "set-function-length": "^1.1.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -226,9 +217,9 @@
             }
         },
         "node_modules/define-data-property": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.0.tgz",
-            "integrity": "sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+            "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
             "dependencies": {
                 "get-intrinsic": "^1.2.1",
                 "gopd": "^1.0.1",
@@ -263,25 +254,25 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.2.tgz",
-            "integrity": "sha512-YoxfFcDmhjOgWPWsV13+2RNjq1F6UQnfs+8TftwNqtzlmFzEXvlUwdrNrYeaizfjQzRMxkZ6ElWMOJIFKdVqwA==",
+            "version": "1.22.3",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.3.tgz",
+            "integrity": "sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==",
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.0",
                 "arraybuffer.prototype.slice": "^1.0.2",
                 "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
+                "call-bind": "^1.0.5",
                 "es-set-tostringtag": "^2.0.1",
                 "es-to-primitive": "^1.2.1",
                 "function.prototype.name": "^1.1.6",
-                "get-intrinsic": "^1.2.1",
+                "get-intrinsic": "^1.2.2",
                 "get-symbol-description": "^1.0.0",
                 "globalthis": "^1.0.3",
                 "gopd": "^1.0.1",
-                "has": "^1.0.3",
                 "has-property-descriptors": "^1.0.0",
                 "has-proto": "^1.0.1",
                 "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0",
                 "internal-slot": "^1.0.5",
                 "is-array-buffer": "^3.0.2",
                 "is-callable": "^1.2.7",
@@ -291,7 +282,7 @@
                 "is-string": "^1.0.7",
                 "is-typed-array": "^1.1.12",
                 "is-weakref": "^1.0.2",
-                "object-inspect": "^1.12.3",
+                "object-inspect": "^1.13.1",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.4",
                 "regexp.prototype.flags": "^1.5.1",
@@ -305,7 +296,7 @@
                 "typed-array-byte-offset": "^1.0.0",
                 "typed-array-length": "^1.0.4",
                 "unbox-primitive": "^1.0.2",
-                "which-typed-array": "^1.1.11"
+                "which-typed-array": "^1.1.13"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -315,13 +306,13 @@
             }
         },
         "node_modules/es-set-tostringtag": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
-            "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
+            "integrity": "sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==",
             "dependencies": {
-                "get-intrinsic": "^1.1.3",
-                "has": "^1.0.3",
-                "has-tostringtag": "^1.0.0"
+                "get-intrinsic": "^1.2.2",
+                "has-tostringtag": "^1.0.0",
+                "hasown": "^2.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -393,9 +384,12 @@
             }
         },
         "node_modules/function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/function.prototype.name": {
             "version": "1.1.6",
@@ -423,14 +417,14 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-            "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+            "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
+                "function-bind": "^1.1.2",
                 "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3"
+                "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -476,14 +470,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/has": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
-            "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/has-bigints": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -493,11 +479,11 @@
             }
         },
         "node_modules/has-property-descriptors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-            "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+            "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
             "dependencies": {
-                "get-intrinsic": "^1.1.1"
+                "get-intrinsic": "^1.2.2"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -539,6 +525,17 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/hasown": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+            "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/ieee754": {
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -552,12 +549,12 @@
             "optional": true
         },
         "node_modules/internal-slot": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
-            "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
+            "integrity": "sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==",
             "dependencies": {
-                "get-intrinsic": "^1.2.0",
-                "has": "^1.0.3",
+                "get-intrinsic": "^1.2.2",
+                "hasown": "^2.0.0",
                 "side-channel": "^1.0.4"
             },
             "engines": {
@@ -798,9 +795,9 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.12.3",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-            "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+            "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -814,12 +811,12 @@
             }
         },
         "node_modules/object.assign": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-            "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+            "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.4",
+                "call-bind": "^1.0.5",
+                "define-properties": "^1.2.1",
                 "has-symbols": "^1.0.3",
                 "object-keys": "^1.1.1"
             },
@@ -836,10 +833,20 @@
             "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
             "optional": true
         },
+        "node_modules/querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+            "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+            "optional": true,
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
         "node_modules/reflect-metadata": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-            "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+            "version": "0.1.14",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
+            "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A=="
         },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.1",
@@ -897,6 +904,20 @@
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
             "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
             "optional": true
+        },
+        "node_modules/set-function-length": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
+            "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+            "dependencies": {
+                "define-data-property": "^1.1.1",
+                "get-intrinsic": "^1.2.1",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/set-function-name": {
             "version": "2.0.1",
@@ -1080,16 +1101,6 @@
                 "querystring": "0.2.0"
             }
         },
-        "node_modules/url/node_modules/querystring": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-            "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-            "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-            "optional": true,
-            "engines": {
-                "node": ">=0.4.x"
-            }
-        },
         "node_modules/util": {
             "version": "0.12.5",
             "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -1127,12 +1138,12 @@
             }
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
-            "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
+            "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
             "dependencies": {
                 "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
+                "call-bind": "^1.0.4",
                 "for-each": "^0.3.3",
                 "gopd": "^1.0.1",
                 "has-tostringtag": "^1.0.0"

--- a/PagerDuty-Services-Service/package.json
+++ b/PagerDuty-Services-Service/package.json
@@ -13,7 +13,7 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "1.0.3",
+        "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.5",
         "axios": "^0.27.2",
         "class-transformer": "0.3.1"
     },


### PR DESCRIPTION
Update the version of typescript library (to 1.0.5) due to mismatch between Service resource and common module, causing build error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.