### PR TITLE
fix: use `events.pagerduty.com` for the US integration URL host

### DIFF
--- a/PagerDuty-Services-Integration/src/handlers.ts
+++ b/PagerDuty-Services-Integration/src/handlers.ts
@@ -95,8 +95,8 @@ class Resource extends AbstractPagerDutyResource<ResourceModel, IntegrationPaylo
         }
 
         if (from.integration_key && from.html_url) {
-            const region = from.html_url.indexOf('eu.pagerduty.com') > -1 ? 'eu' : 'us';
-            params.integrationUrl = `https://events.${region}.pagerduty.com/integration/${from.integration_key}/enqueue`;
+            const host = from.html_url.indexOf('eu.pagerduty.com') > -1 ? 'events.eu.pagerduty.com' : 'events.pagerduty.com';
+            params.integrationUrl = `https://${host}/integration/${from.integration_key}/enqueue`;
         } else {
             params.integrationUrl = "";
         }


### PR DESCRIPTION
`events.us.pagerduty.com` doesn't seem to be a valid hostname for the events API endpoint. The UI and docs all point to `events.pagerduty.com` being the hostname. Even though `events.us.pagerduty.com` does seem to resolve, the SSL certificate is invalid.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.